### PR TITLE
SLING-12882 Migrate Starter Content to sling api 3.0 and models api 2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.starter.content</artifactId>
-    <version>1.0.17-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Apache Sling Starter Content</name>
     <description>This bundle provides content that is loaded in the JCR repository
@@ -42,11 +42,10 @@
     </scm>
 
     <properties>
-        <sling.java.version>11</sling.java.version>
+        <sling.java.version>17</sling.java.version>
         <frontend.target>target/frontend</frontend.target>
         <project.build.outputTimestamp>1734087596</project.build.outputTimestamp>
         <oak.version>1.16.0</oak.version>
-        <junit-jupiter.version>5.10.0</junit-jupiter.version>
     </properties>
     <dependencies>
         <dependency>
@@ -77,20 +76,21 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.27.0</version>
+            <version>3.0.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>1.4.2</version>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -120,8 +120,14 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.jackrabbit.accessmanager</artifactId>
-            <version>4.0.2</version>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -132,13 +138,11 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.models.api</artifactId>
-            <version>2.0.0-SNAPSHOT</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.jcr.jackrabbit.accessmanager</artifactId>
-            <version>5.0.0-SNAPSHOT</version>
+            <version>5.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/org/apache/sling/starter/access/models/AccessFormPage.java
+++ b/src/main/java/org/apache/sling/starter/access/models/AccessFormPage.java
@@ -20,15 +20,16 @@ package org.apache.sling.starter.access.models;
 
 import javax.annotation.PostConstruct;
 import javax.jcr.Node;
-import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.jcr.jackrabbit.accessmanager.PrivilegesInfo;
 import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
+import org.apache.sling.models.annotations.injectorspecific.SlingObject;
 
 /**
  * Base class for common ACL/ACE functionality
@@ -36,11 +37,11 @@ import org.apache.sling.models.annotations.injectorspecific.ScriptVariable;
 public abstract class AccessFormPage {
     protected PrivilegesInfo privilegesInfo = null;
 
-    @ScriptVariable
-    protected SlingHttpServletRequest request;
+    @SlingObject
+    protected SlingJakartaHttpServletRequest request;
 
-    @ScriptVariable
-    protected SlingHttpServletResponse response;
+    @SlingObject
+    protected SlingJakartaHttpServletResponse response;
 
     @ScriptVariable
     protected Resource resource;

--- a/src/main/java/org/apache/sling/starter/access/models/Ace.java
+++ b/src/main/java/org/apache/sling/starter/access/models/Ace.java
@@ -59,7 +59,7 @@ import org.apache.jackrabbit.api.security.user.UserManager;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionDefinition;
 import org.apache.jackrabbit.oak.spi.security.authorization.restriction.RestrictionProvider;
 import org.apache.jackrabbit.oak.spi.security.privilege.PrivilegeConstants;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.request.RequestParameter;
 import org.apache.sling.api.request.RequestParameterMap;
 import org.apache.sling.api.resource.ResourceNotFoundException;
@@ -75,7 +75,7 @@ import org.jetbrains.annotations.Nullable;
 /**
  * The ace page options.
  */
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class Ace extends AccessFormPage {
     // for principal ace
     protected static final String PATH_REPOSITORY = "/:repository";

--- a/src/main/java/org/apache/sling/starter/access/models/Ace.java
+++ b/src/main/java/org/apache/sling/starter/access/models/Ace.java
@@ -40,7 +40,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
@@ -131,8 +130,8 @@ public class Ace extends AccessFormPage {
         boolean isInValidPrincipal = true;
         if (principalId != null && !principalId.isEmpty()) {
             Session session = request.getResourceResolver().adaptTo(Session.class);
-            if (session instanceof JackrabbitSession) {
-                UserManager userManager = ((JackrabbitSession) session).getUserManager();
+            if (session instanceof JackrabbitSession jackrabbitSession) {
+                UserManager userManager = jackrabbitSession.getUserManager();
                 if (userManager != null) {
                     Authorizable authorizable = userManager.getAuthorizable(principalId);
                     if (authorizable != null) {
@@ -421,8 +420,8 @@ public class Ace extends AccessFormPage {
         } else {
             // non-existing path. We can't determine what is supported there, so consider all registered privileges
             Workspace workspace = jcrSession.getWorkspace();
-            if (workspace instanceof JackrabbitWorkspace) {
-                PrivilegeManager privilegeManager = ((JackrabbitWorkspace) workspace).getPrivilegeManager();
+            if (workspace instanceof JackrabbitWorkspace jackrabbitWorkspace) {
+                PrivilegeManager privilegeManager = jackrabbitWorkspace.getPrivilegeManager();
                 supportedPrivileges = privilegeManager.getRegisteredPrivileges();
             }
         }
@@ -484,9 +483,8 @@ public class Ace extends AccessFormPage {
                     if (allowJsonValue != null) {
                         privilegeItem.setAllowExists(true);
                         privilegeItem.setGranted(true);
-                        if (allowJsonValue instanceof JsonObject) {
-                            List<RestrictionItem> restrictionItems =
-                                    jsonToRestrictionItems(srMap, (JsonObject) allowJsonValue);
+                        if (allowJsonValue instanceof JsonObject jsonObject) {
+                            List<RestrictionItem> restrictionItems = jsonToRestrictionItems(srMap, jsonObject);
                             privilegeItem.setAllowRestrictions(restrictionItems);
                         }
                     }
@@ -494,9 +492,8 @@ public class Ace extends AccessFormPage {
                     if (denyJsonValue != null) {
                         privilegeItem.setDenyExists(true);
                         privilegeItem.setDenied(true);
-                        if (denyJsonValue instanceof JsonObject) {
-                            List<RestrictionItem> restrictionItems =
-                                    jsonToRestrictionItems(srMap, (JsonObject) denyJsonValue);
+                        if (denyJsonValue instanceof JsonObject jsonObject) {
+                            List<RestrictionItem> restrictionItems = jsonToRestrictionItems(srMap, jsonObject);
                             privilegeItem.setDenyRestrictions(restrictionItems);
                         }
                     }
@@ -515,15 +512,14 @@ public class Ace extends AccessFormPage {
             if (rd != null) {
                 Object value = null;
                 JsonValue jsonValue = entry.getValue();
-                if (jsonValue instanceof JsonArray) {
-                    JsonArray jsonArray = (JsonArray) jsonValue;
+                if (jsonValue instanceof JsonArray jsonArray) {
                     String[] values = new String[jsonArray.size()];
                     for (int i = 0; i < values.length; i++) {
                         values[i] = jsonArray.getString(i);
                     }
                     value = values;
-                } else if (jsonValue instanceof JsonString) {
-                    value = ((JsonString) jsonValue).getString();
+                } else if (jsonValue instanceof JsonString jsonString) {
+                    value = jsonString.getString();
                 }
                 restrictionItems.add(new RestrictionItem(rd, value, true));
             }
@@ -543,7 +539,7 @@ public class Ace extends AccessFormPage {
         return getSupportedRestrictions().stream()
                 .map(rd -> new RestrictionDefinitionInfo(rd.getName(), rd))
                 .sorted(Comparator.comparing(RestrictionDefinitionInfo::getDisplayName))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/src/main/java/org/apache/sling/starter/access/models/Acl.java
+++ b/src/main/java/org/apache/sling/starter/access/models/Acl.java
@@ -32,12 +32,12 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import org.apache.jackrabbit.api.JackrabbitSession;
 import org.apache.jackrabbit.api.security.principal.PrincipalManager;
-import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.jcr.jackrabbit.accessmanager.GetAcl;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.injectorspecific.OSGiService;
 
-@Model(adaptables = SlingHttpServletRequest.class)
+@Model(adaptables = SlingJakartaHttpServletRequest.class)
 public class Acl extends AccessFormPage {
     private List<PrincipalPrivilege> principalPrivilegeList;
 

--- a/src/main/java/org/apache/sling/starter/access/models/RestrictionItem.java
+++ b/src/main/java/org/apache/sling/starter/access/models/RestrictionItem.java
@@ -49,20 +49,16 @@ public class RestrictionItem {
 
     public String getValue() throws RepositoryException {
         String v = null;
-        if (value instanceof Value) {
-            v = ((Value) value).getString();
-        } else if (value instanceof Value[]) {
-            Value[] va = (Value[]) value;
+        if (value instanceof Value valueObj) {
+            v = valueObj.getString();
+        } else if (value instanceof Value[] va) {
             if (va.length > 0) {
                 v = va[0].getString();
             }
-        } else if (value instanceof String) {
-            v = (String) value;
-        } else if (value instanceof String[]) {
-            String[] values = (String[]) value;
-            if (values.length > 0) {
-                v = values[0];
-            }
+        } else if (value instanceof String valueString) {
+            v = valueString;
+        } else if (value instanceof String[] values && values.length > 0) {
+            v = values[0];
         }
 
         if (v == null) {
@@ -74,17 +70,16 @@ public class RestrictionItem {
 
     public List<String> getValues() throws RepositoryException {
         List<String> values = new ArrayList<>();
-        if (value instanceof Value) {
-            values.add(((Value) value).getString());
-        } else if (value instanceof Value[]) {
-            Value[] va = (Value[]) value;
+        if (value instanceof Value valueObj) {
+            values.add(valueObj.getString());
+        } else if (value instanceof Value[] va) {
             for (Value v : va) {
                 values.add(v.getString());
             }
-        } else if (value instanceof String) {
-            values.add((String) value);
-        } else if (value instanceof String[]) {
-            values.addAll(Arrays.asList((String[]) value));
+        } else if (value instanceof String stringValue) {
+            values.add(stringValue);
+        } else if (value instanceof String[] stringValues) {
+            values.addAll(Arrays.asList(stringValues));
         }
         if (values.isEmpty()) {
             // empty string if no values yet

--- a/src/main/java/org/apache/sling/starter/access/models/package-info.java
+++ b/src/main/java/org/apache/sling/starter/access/models/package-info.java
@@ -17,5 +17,5 @@
  * under the License.
  */
 
-@org.osgi.annotation.versioning.Version("1.0.0")
+@org.osgi.annotation.versioning.Version("2.0.0")
 package org.apache.sling.starter.access.models;

--- a/src/test/java/org/apache/sling/starter/access/models/AccessFormPageTest.java
+++ b/src/test/java/org/apache/sling/starter/access/models/AccessFormPageTest.java
@@ -21,8 +21,8 @@ package org.apache.sling.starter.access.models;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
-import org.apache.sling.api.SlingHttpServletRequest;
-import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.jcr.jackrabbit.accessmanager.PrivilegesInfo;
@@ -48,8 +48,8 @@ abstract class AccessFormPageTest {
         page = createPageModel();
         page.privilegesInfo = Mockito.mock(PrivilegesInfo.class);
         page.resource = Mockito.mock(Resource.class);
-        page.request = Mockito.mock(SlingHttpServletRequest.class);
-        page.response = Mockito.mock(SlingHttpServletResponse.class);
+        page.request = Mockito.mock(SlingJakartaHttpServletRequest.class);
+        page.response = Mockito.mock(SlingJakartaHttpServletResponse.class);
 
         rr = Mockito.mock(ResourceResolver.class);
         currentNode = Mockito.mock(Node.class);


### PR DESCRIPTION
bump bundle major version to 2.0.0
bump minimum java version to 17

bump models.api to 2.0.0-SNAPSHOT (see [SLING-12874](https://issues.apache.org/jira/browse/SLING-12874))
bump sling api to 3.x
bump org.apache.sling.jcr.jackrabbit.accessmanager to 5.0.0-SNAPSHOT ([SLING-12868](https://issues.apache.org/jira/browse/SLING-12868))

migrate the javax.servlet references to jakarta.servlet